### PR TITLE
docs: pin install instructions to stable branch

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -154,10 +154,10 @@ FastMCP server exposing three tools:
 
 ```bash
 # Via uvx (recommended for MCP)
-uvx --from git+https://github.com/alexsvdk/gigaplexity-mcp gigaplexity-mcp
+uvx --from git+https://github.com/alexsvdk/gigaplexity-mcp@stable gigaplexity-mcp
 
 # Via pip
-pip install git+https://github.com/alexsvdk/gigaplexity-mcp
+pip install git+https://github.com/alexsvdk/gigaplexity-mcp@stable
 ```
 
 ## MCP Configuration
@@ -167,7 +167,7 @@ pip install git+https://github.com/alexsvdk/gigaplexity-mcp
   "mcpServers": {
     "gigaplexity": {
       "command": "uvx",
-      "args": ["--from", "git+https://github.com/alexsvdk/gigaplexity-mcp", "gigaplexity-mcp"],
+      "args": ["--from", "git+https://github.com/alexsvdk/gigaplexity-mcp@stable", "gigaplexity-mcp"],
       "env": {
         "GIGACHAT_SM_SESS": "your-jwt-token",
         "GIGACHAT_USER_ID": "your-user-id",

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/alexsvdk/gigaplexity-mcp",
+        "git+https://github.com/alexsvdk/gigaplexity-mcp@stable",
         "gigaplexity-mcp"
       ],
       "env": {


### PR DESCRIPTION
## Summary\n- pin install source URLs to  in docs\n\n## Files\n- README.md\n- ARCHITECTURE.md\n\n## Why\nEnsure users install stable code instead of experimental changes from default branch.