### PR TITLE
fix: update app version to 0.94.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - 
 
 ### Changed
-- 
+- Updated app version to 0.94.11 to match current GigaChat web interface
 
 ### Fixed
 - 

--- a/src/gigaplexity/config.py
+++ b/src/gigaplexity/config.py
@@ -96,7 +96,7 @@ class GigaplexitySettings(BaseSettings):
     # Optional
     user_agent: str = "random"
     base_url: str = "https://giga.chat"
-    app_version: str = "0.94.4"
+    app_version: str = "0.94.11"
     language: str = "en"
     timezone: str = "UTC"
 


### PR DESCRIPTION
## Описание

Обновлена версия приложения в заголовке `X-Application-Version` с `0.94.4` на `0.94.11` для соответствия текущей версии веб-интерфейса GigaChat.

## Проблема

Проект перестал работать из-за устаревшей версии приложения в заголовках запросов. Анализ HAR файла показал, что текущая версия веб-интерфейса - `0.94.11`.

## Решение

- Обновлен `app_version` в `src/gigaplexity/config.py` с `0.94.4` на `0.94.11`
- Обновлен CHANGELOG.md

## Тестирование

Протестированы все режимы работы:
- ✅ ASK mode - работает
- ✅ REASON mode - работает  
- ✅ RESEARCH mode - работает

Все запросы успешно выполняются с новой версией.